### PR TITLE
Add react version

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,5 +77,10 @@ module.exports = {
     describe: false,
     before: false,
     it: false
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
   }
 };


### PR DESCRIPTION
Removes the following warning:

> Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.